### PR TITLE
update actions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,15 +13,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: '3.12'
+        cache: pip
+
+    - name: Update pip
+      run: |
+        pip install -U pip
+
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install setuptools wheel twine
+
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/python-push.yml
+++ b/.github/workflows/python-push.yml
@@ -8,30 +8,45 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        flake8 victor_smart_kill
-    - name: Analysing the code with pylint
-      run: |
-        pylint --version
-        pylint victor_smart_kill
-    - name: Analysing the code with mypy
-      run: |
-        mypy -p victor_smart_kill 
-    - name: Test with pytest
-      run: |
-        pytest tests/test_trap_mapping.py
-      
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Update pip
+        run: |
+          pip install -U pip
+
+      - name: Install dependencies
+        run: |
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Lint with flake8
+        run: |
+          flake8 victor_smart_kill
+
+      - name: Analyse the code with pylint
+        run: |
+          pylint victor_smart_kill
+
+      - name: Analyse the code with mypy
+        run: |
+          mypy -p victor_smart_kill
+
+      - name: Test with pytest
+        run: |
+          pytest tests/test_trap_mapping.py

--- a/.github/workflows/python-push.yml
+++ b/.github/workflows/python-push.yml
@@ -35,6 +35,10 @@ jobs:
         run: |
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
+      - name: Check formatting with black
+        run: |
+          black --check victor_smart_kill
+
       - name: Lint with flake8
         run: |
           flake8 victor_smart_kill

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "httpx~=0.20",
         "marshmallow~=3.8",


### PR DESCRIPTION
I updated the versions of actions used in workflows as some of them were quite old and used some NodeJS versions are going to be deprecated soon. Because python 3.6 will not install via setup-python v5, I also dropped support but retained 3.7-3.12 (and added a test for each version)

Also disabled fast-fail on linting workflow so that all versions are tested even if some fail.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
Spring 2024 is the target window to transfer to node 20, although there is no finalized date.